### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,8 +6,8 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-G15  	KEYWORD1
-ServoID KEYWORD1
+G15	KEYWORD1
+ServoID	KEYWORD1
 CW	KEYWORD1
 CCW	KEYWORD1	
 ON	KEYWORD1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords